### PR TITLE
Add video buffering control for capture pins

### DIFF
--- a/source/device.hpp
+++ b/source/device.hpp
@@ -106,15 +106,16 @@ struct HDevice {
 
 	bool CreateGraph();
 	bool FindCrossbar(IBaseFilter *filter, IBaseFilter **crossbar);
-	bool ConnectPins(const GUID &category, const GUID &type,
-			 IBaseFilter *filter, IBaseFilter *capture);
-	bool RenderFilters(const GUID &category, const GUID &type,
-			   IBaseFilter *filter, IBaseFilter *capture);
-	void SetAudioBuffering(int bufferingMs);
-	bool ConnectFilters();
-	void DisconnectFilters();
-	Result Start();
-	void Stop();
+        bool ConnectPins(const GUID &category, const GUID &type,
+                         IBaseFilter *filter, IBaseFilter *capture);
+        bool RenderFilters(const GUID &category, const GUID &type,
+                           IBaseFilter *filter, IBaseFilter *capture);
+        void SetVideoBuffering(int bufferingMs);
+        void SetAudioBuffering(int bufferingMs);
+        bool ConnectFilters();
+        void DisconnectFilters();
+        Result Start();
+        void Stop();
 };
 
 }; /* namespace DShow */


### PR DESCRIPTION
## Summary
- Allow configuring video capture buffering using IAMBufferNegotiation
- Request minimal buffering when connecting video capture filters

## Testing
- `cmake -S . -B build` *(fails: Cannot find source file external/capture-device-support/Library/EGAVResult.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_688f78583178832cb03c65964cb9f009