### PR TITLE
Allow configuring output buffer count

### DIFF
--- a/dshowcapture.hpp
+++ b/dshowcapture.hpp
@@ -257,10 +257,17 @@ public:
 struct VideoEncoderConfig : DeviceId {
 	int fpsNumerator;
 	int fpsDenominator;
-	int bitrate;
-	int keyframeInterval;
-	int cx;
-	int cy;
+        int bitrate;
+        int keyframeInterval;
+        int cx;
+        int cy;
+
+        /**
+                 * Desired number of output buffers. Use lower values
+                 * (such as 1 or 2) for low-latency encoding. Defaults to 4
+                 * when set to 0.
+                 */
+        int buffers = 0;
 };
 
 struct EncoderPacket {

--- a/source/encoder.cpp
+++ b/source/encoder.cpp
@@ -215,9 +215,10 @@ bool HVideoEncoder::SetupEncoder(IBaseFilter *filter)
 
 	encoder = filter;
 	device = std::move(deviceFilter);
-	capture = new CaptureFilter(captureInfo);
-	output = new OutputFilter(VideoFormat::YV12, config.cx, config.cy,
-				  frameTime);
+        capture = new CaptureFilter(captureInfo);
+        int buffers = config.buffers ? config.buffers : 4;
+        output = new OutputFilter(VideoFormat::YV12, config.cx, config.cy,
+                                  frameTime, buffers);
 
 	graph->AddFilter(output, nullptr);
 	graph->AddFilter(device, L"Device Filter");

--- a/source/output-filter.hpp
+++ b/source/output-filter.hpp
@@ -45,19 +45,20 @@ class OutputPin : public IPin, public IAMStreamConfig, public IKsPropertySet {
 	ComPtr<IPin> connectedPin;
 	OutputFilter *filter;
 	volatile bool flushing = false;
-	ComPtr<IMemAllocator> allocator;
-	ComPtr<IMediaSample> sample;
-	size_t bufSize;
+        ComPtr<IMemAllocator> allocator;
+        ComPtr<IMediaSample> sample;
+        size_t bufSize;
+        int bufferCount = 4;
 
 	bool IsValidMediaType(const AM_MEDIA_TYPE *pmt) const;
 
 	bool AllocateBuffers(IPin *target, bool connecting = false);
 
 public:
-	OutputPin(OutputFilter *filter);
-	OutputPin(OutputFilter *filter, VideoFormat format, int cx, int cy,
-		  long long interval);
-	virtual ~OutputPin();
+        OutputPin(OutputFilter *filter, int buffers = 4);
+        OutputPin(OutputFilter *filter, VideoFormat format, int cx, int cy,
+                  long long interval, int buffers = 4);
+        virtual ~OutputPin();
 
 	STDMETHODIMP QueryInterface(REFIID riid, void **ppv);
 	STDMETHODIMP_(ULONG) AddRef();
@@ -144,8 +145,9 @@ protected:
 	ComPtr<IReferenceClock> clock;
 
 public:
-	OutputFilter();
-	OutputFilter(VideoFormat format, int cx, int cy, long long interval);
+        OutputFilter(int buffers = 4);
+        OutputFilter(VideoFormat format, int cx, int cy, long long interval,
+                     int buffers = 4);
 	virtual ~OutputFilter();
 
 	// IUnknown methods
@@ -183,8 +185,11 @@ public:
 	}
 
 	inline int GetCX() const { return pin->GetCX(); }
-	inline int GetCY() const { return pin->GetCY(); }
-	inline long long GetInterval() const { return pin->GetInterval(); }
+        inline int GetCY() const { return pin->GetCY(); }
+        inline long long GetInterval() const { return pin->GetInterval(); }
+
+        inline void SetBufferCount(int buffers) { pin->bufferCount = buffers; }
+        inline int GetBufferCount() const { return pin->bufferCount; }
 
 	inline void AddVideoFormat(VideoFormat format, int cx, int cy,
 				   long long interval)


### PR DESCRIPTION
## Summary
- allow setting output buffer count via `VideoEncoderConfig`
- expose buffer count controls for output filter
- use requested buffer count when allocating IMemAllocator buffers

## Testing
- `cmake -S . -B build` *(fails: WinSock2.h missing)*
- `cmake --build build` *(fails: WinSock2.h missing)*


------
https://chatgpt.com/codex/tasks/task_e_688f785cc998832cbbae8d7fddb6f27c