### PR TITLE
Expose video buffering control

### DIFF
--- a/dshowcapture.hpp
+++ b/dshowcapture.hpp
@@ -165,8 +165,8 @@ struct Config : DeviceId {
 };
 
 struct VideoConfig : Config {
-	VideoProc callback;
-	ReactivateProc reactivateCallback;
+        VideoProc callback;
+        ReactivateProc reactivateCallback;
 
 	/** Desired width/height of video. */
 	int cx = 0, cy_abs = 0;
@@ -174,14 +174,17 @@ struct VideoConfig : Config {
 	/** Whether or not cy was negative. */
 	bool cy_flip = false;
 
-	/** Desired frame interval (in 100-nanosecond units) */
-	long long frameInterval = 0;
+        /** Desired frame interval (in 100-nanosecond units) */
+        long long frameInterval = 0;
 
 	/** Internal video format. */
 	VideoFormat internalFormat = VideoFormat::Any;
 
-	/** Desired video format. */
-	VideoFormat format = VideoFormat::Any;
+        /** Desired video format. */
+        VideoFormat format = VideoFormat::Any;
+
+        /** Desired buffer length in milliseconds */
+        int buffer = 0;
 };
 
 struct AudioConfig : Config {

--- a/source/device.cpp
+++ b/source/device.cpp
@@ -767,7 +767,7 @@ void HDevice::SetVideoBuffering(int bufferingMs)
         uint64_t bytesPerSec = frameSize * fps;
 
         ALLOCATOR_PROPERTIES props;
-        props.cBuffers = -1;
+        props.cBuffers = 1;
         props.cbBuffer = (LONG)(bytesPerSec * (uint64_t)bufferingMs / 1000ULL);
         props.cbAlign = -1;
         props.cbPrefix = -1;
@@ -831,7 +831,8 @@ bool HDevice::ConnectFilters()
                                                VideoFormat::P010;
                 SetVendorTonemapperUsage(videoFilter, enable_tonemapper);
 
-                long bufferMs = (long)(videoConfig.frameInterval / 10000);
+                long bufferMs = videoConfig.buffer ? videoConfig.buffer
+                                                  : (long)(videoConfig.frameInterval / 10000);
                 if (bufferMs <= 0)
                         bufferMs = 1;
                 SetVideoBuffering((int)bufferMs);


### PR DESCRIPTION
## Summary
- allow specifying video buffering duration via `VideoConfig::buffer`
- use `props.cBuffers = 1` for single-buffer video capture

## Testing
- `cmake -S . -B build` *(fails: Cannot find source file: external/capture-device-support/Library/EGAVResult.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68906f59b920832cbe014c6ab3d53925