### PR TITLE
Reduce default output buffers

### DIFF
--- a/source/encoder.cpp
+++ b/source/encoder.cpp
@@ -216,7 +216,7 @@ bool HVideoEncoder::SetupEncoder(IBaseFilter *filter)
 	encoder = filter;
 	device = std::move(deviceFilter);
         capture = new CaptureFilter(captureInfo);
-        int buffers = config.buffers ? config.buffers : 4;
+        int buffers = config.buffers ? config.buffers : 2;
         output = new OutputFilter(VideoFormat::YV12, config.cx, config.cy,
                                   frameTime, buffers);
 

--- a/source/output-filter.hpp
+++ b/source/output-filter.hpp
@@ -48,16 +48,16 @@ class OutputPin : public IPin, public IAMStreamConfig, public IKsPropertySet {
         ComPtr<IMemAllocator> allocator;
         ComPtr<IMediaSample> sample;
         size_t bufSize;
-        int bufferCount = 4;
+        int bufferCount = 2;
 
 	bool IsValidMediaType(const AM_MEDIA_TYPE *pmt) const;
 
 	bool AllocateBuffers(IPin *target, bool connecting = false);
 
 public:
-        OutputPin(OutputFilter *filter, int buffers = 4);
+        OutputPin(OutputFilter *filter, int buffers = 2);
         OutputPin(OutputFilter *filter, VideoFormat format, int cx, int cy,
-                  long long interval, int buffers = 4);
+                  long long interval, int buffers = 2);
         virtual ~OutputPin();
 
 	STDMETHODIMP QueryInterface(REFIID riid, void **ppv);
@@ -145,9 +145,9 @@ protected:
 	ComPtr<IReferenceClock> clock;
 
 public:
-        OutputFilter(int buffers = 4);
+        OutputFilter(int buffers = 2);
         OutputFilter(VideoFormat format, int cx, int cy, long long interval,
-                     int buffers = 4);
+                     int buffers = 2);
 	virtual ~OutputFilter();
 
 	// IUnknown methods


### PR DESCRIPTION
## Summary
- Reduce OutputPin default buffer count to 2
- Propagate new default through OutputFilter and encoder setup

## Testing
- `cmake -S . -B build` *(fails: Cannot find source file: external/capture-device-support/Library/EGAVResult.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68906fbed938832cab956d9140b466b6