### PR TITLE
Add option to disable DirectShow clock

### DIFF
--- a/dshowcapture.hpp
+++ b/dshowcapture.hpp
@@ -214,7 +214,8 @@ struct AudioConfig : Config {
 };
 
 class DSHOWCAPTURE_EXPORT Device {
-	HDevice *context;
+        HDevice *context;
+        bool clockless = false;
 
 public:
 	Device(InitGraph initialize = InitGraph::False);
@@ -222,8 +223,21 @@ public:
 
 	bool Valid() const;
 
-	bool ResetGraph();
-	void ShutdownGraph();
+        bool ResetGraph();
+        void ShutdownGraph();
+
+        /**
+                 * Enable or disable use of the graph's reference clock.
+                 * When disabled, filters operate asynchronously.
+                 */
+        void SetClockless(bool clockless);
+
+        /**
+                 * Retrieves current dropped frame and timing irregularity
+                 * statistics when running without a clock.
+                 */
+        void GetTimingStats(unsigned long &dropped,
+                             unsigned long &irregular) const;
 
 	bool SetVideoConfig(VideoConfig *config);
 	bool SetAudioConfig(AudioConfig *config);
@@ -250,8 +264,8 @@ public:
 		 */
 	void OpenDialog(void *hwnd, DialogType type) const;
 
-	static bool EnumVideoDevices(std::vector<VideoDevice> &devices);
-	static bool EnumAudioDevices(std::vector<AudioDevice> &devices);
+        static bool EnumVideoDevices(std::vector<VideoDevice> &devices);
+        static bool EnumAudioDevices(std::vector<AudioDevice> &devices);
 };
 
 struct VideoEncoderConfig : DeviceId {

--- a/source/device.hpp
+++ b/source/device.hpp
@@ -65,9 +65,15 @@ struct HDevice {
 	bool encodedDevice = false;
 	bool rotatableDevice = false;
 	bool deviceHdrSignal = false;
-	bool reactivatePending = false;
-	bool initialized;
-	bool active;
+        bool reactivatePending = false;
+        bool initialized;
+        bool active;
+
+        bool clockless = false;
+        unsigned long droppedFrames = 0;
+        unsigned long timingIrregularities = 0;
+        long long lastVideoStop = 0;
+        bool haveLastVideoStop = false;
 
 	EncodedData encodedVideo;
 	EncodedData encodedAudio;
@@ -82,11 +88,15 @@ struct HDevice {
 	bool EnsureActive(const wchar_t *func);
 	bool EnsureInactive(const wchar_t *func);
 
-	inline void SendToCallback(bool video, unsigned char *data, size_t size,
-				   long long startTime, long long stopTime,
-				   long rotation);
+        inline void SendToCallback(bool video, unsigned char *data, size_t size,
+                                   long long startTime, long long stopTime,
+                                   long rotation);
 
-	void Receive(bool video, IMediaSample *sample);
+        void Receive(bool video, IMediaSample *sample);
+
+        void SetClockless(bool clockless);
+        void GetTimingStats(unsigned long &dropped,
+                             unsigned long &irregular) const;
 
 	bool SetupEncodedVideoCapture(IBaseFilter *filter, VideoConfig &config,
 				      const EncodedDevice &info);

--- a/source/dshowcapture.cpp
+++ b/source/dshowcapture.cpp
@@ -30,8 +30,9 @@ namespace DShow {
 
 Device::Device(InitGraph initialize) : context(new HDevice)
 {
-	if (initialize == InitGraph::True)
-		context->CreateGraph();
+        context->SetClockless(clockless);
+        if (initialize == InitGraph::True)
+                context->CreateGraph();
 }
 
 Device::~Device()
@@ -46,17 +47,19 @@ bool Device::Valid() const
 
 bool Device::ResetGraph()
 {
-	/* cheap and easy way to clear all the filters */
-	delete context;
-	context = new HDevice;
+        /* cheap and easy way to clear all the filters */
+        delete context;
+        context = new HDevice;
+        context->SetClockless(clockless);
 
-	return context->CreateGraph();
+        return context->CreateGraph();
 }
 
 void Device::ShutdownGraph()
 {
-	delete context;
-	context = new HDevice;
+        delete context;
+        context = new HDevice;
+        context->SetClockless(clockless);
 }
 
 bool Device::SetVideoConfig(VideoConfig *config)
@@ -71,17 +74,29 @@ bool Device::SetAudioConfig(AudioConfig *config)
 
 bool Device::ConnectFilters()
 {
-	return context->ConnectFilters();
+        return context->ConnectFilters();
 }
 
 Result Device::Start()
 {
-	return context->Start();
+        return context->Start();
 }
 
 void Device::Stop()
 {
-	context->Stop();
+        context->Stop();
+}
+
+void Device::SetClockless(bool noClock)
+{
+        clockless = noClock;
+        context->SetClockless(noClock);
+}
+
+void Device::GetTimingStats(unsigned long &dropped,
+                             unsigned long &irregular) const
+{
+        context->GetTimingStats(dropped, irregular);
 }
 
 bool Device::GetVideoConfig(VideoConfig &config) const


### PR DESCRIPTION
## Summary
- add Device::SetClockless and GetTimingStats to toggle reference clock usage and report timing issues
- disable the graph's reference clock when clockless mode is enabled
- track dropped and irregular frames when running without a clock

## Testing
- `cmake ..` *(fails: Cannot find source file external/capture-device-support/Library/EGAVResult.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68906fda7da8832c9472ef8847e584b3